### PR TITLE
[Bugfix] Docs dictionary can get too large

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -297,15 +297,26 @@ documents.set('', {
 	doc: Text.of(['\n\n\nStarting doc!\n\n\n'])
 });
 
+function clearDocuments() {
+	documents.clear();
+	console.log('Documents map cleared:', documents);
+}
+
+// Set an interval to clear the map every 2 minutes (120000 milliseconds)
+setInterval(clearDocuments, 1000 * 10);
+
 function getDocument(name: string): Document {
 	const fullPath = path.join('./project', name);
 
 	if (documents.has(name)) return documents.get(name)!;
 
+	io.emit("resetChangeset", name)
+	console.log("Emmited", name)
 	let fileContent = '';
 	try {
 		if (fs.existsSync(fullPath)) {
 			fileContent = fs.readFileSync(fullPath, 'utf-8');
+			console.log(fileContent)
 		} else {
 			fs.writeFileSync(fullPath, `\n\n\nHello World from ${name}\n\n\n`);
 			fileContent = `\n\n\nHello World from ${name}\n\n\n`;
@@ -438,6 +449,8 @@ io.on('connection', (socket: Socket) => {
 	socket.on('pushUpdates', (documentName, version, docUpdates) => {
 		try {
 			detectChanges = false;
+
+
 			let { updates, pending, doc } = getDocument(documentName);
 			docUpdates = JSON.parse(docUpdates);
 

--- a/frontend/app/Editor/Editor.js
+++ b/frontend/app/Editor/Editor.js
@@ -130,6 +130,9 @@ const Home = ({ filename }) => {
 
         socket.on('connect', handleConnect);
 
+        socket.on('resetChangeset', (filepath) => {
+            console.log(filepath)
+        });
         if (socket.connected) {
             handleConnect();
         }

--- a/frontend/app/Editor/Editor.js
+++ b/frontend/app/Editor/Editor.js
@@ -130,9 +130,7 @@ const Home = ({ filename }) => {
 
         socket.on('connect', handleConnect);
 
-        socket.on('resetChangeset', (filepath) => {
-            console.log(filepath)
-        });
+
         if (socket.connected) {
             handleConnect();
         }

--- a/frontend/app/Filetree/Tree.jsx
+++ b/frontend/app/Filetree/Tree.jsx
@@ -40,7 +40,7 @@ export const FileTree = () => {
 
     useEffect(() => {
         // Any additional actions based on filename changes
-        console.log('Current filename:', filename);
+        // console.log('Current filename:', filename);
     }, [filename]);
     const getNodePath = (nodeId, tree) => {
         const path = [];


### PR DESCRIPTION
If opening to many files, the documents dictionary can increase in size permanently until backend restart. This can slow the program down significantly. Files are timestamped and if inactive for 5 minutes, it will be deleted and reset if users are viewing it.
Solution:
```ts
interface Document {
	updates: Update[],
	doc: Text,
	pending: ((value: any) => void)[],
	lastAccessed: number
}
```
```ts
documents.set('', {
	updates: [],
	pending: [],
	doc: Text.of(['\n\n\nStarting doc!\n\n\n']),
	lastAccessed: Date.now()
});
```
```ts
function clearDocuments() {
	const now = Date.now();
	documents.forEach((doc, name) => {
		if (now - doc.lastAccessed > 1000 * 60 * 5) {
			documents.delete(name);
			io.emit("resetFile", name)
		}
	});
}

setInterval(clearDocuments, 1000 * 60 * 1);

```